### PR TITLE
fix: Titanium TSS selector

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,6 +72,7 @@ const selectors = [
     'jsonc', //JSONC
     'qml', //QML
     'jsx', //React JSX
+    'alloy-tss', //TSS (Titanium Style Sheets)
     'tss', //TSS (Titanium Style Sheets)
     'tsx', //TSX
     'ts', //TypeScript


### PR DESCRIPTION
If you open a Titanium project like https://github.com/tidev/kitchensink-v2 and try to prettify a tss file (https://github.com/tidev/kitchensink-v2/blob/master/app/styles/app.tss) it will complain that it can't find a formatter for `alloy-tss`.
Adding `alloy-tss` to the selectors will fix it. Keeping the old `tss` for backwards compatibility. 